### PR TITLE
Fix window overflow in Firefox

### DIFF
--- a/public/chat.css
+++ b/public/chat.css
@@ -4,7 +4,7 @@ html, body {
 }
 
 .flex-1 {
-  flex: 1;
+  flex: 1 1 0;
 }
 
 .flex-2 {


### PR DESCRIPTION
`flex-basis` default to `auto` behaves differently as chrome. override default for correct calculation.

Browser: 
Firefox 48.0.2
<img width="782" alt="2016-09-13 10 15 56 am" src="https://cloud.githubusercontent.com/assets/2762704/18459303/0929e2b6-799b-11e6-8440-cfac533d8378.png">


