### PR TITLE
Workaround for invisible text on login/signup input fields

### DIFF
--- a/public/chat.css
+++ b/public/chat.css
@@ -104,7 +104,7 @@ main.signup fieldset {
 main.login fieldset input,
 main.signup fieldset input{
   width: 100%;
-  padding: 1.4em 0.7em;
+  /* padding: 1.4em 0.7em; */
 }
 
 main.login .button-primary,


### PR DESCRIPTION
This isn't really a fix, but it seems to be a reasonable workaround for issue #34 in the absence of a better fix.  This change allows the input fields on the signup and login forms to be visible while typing.