### PR TITLE
Forward npm test arguments to mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "npm": ">= 6.0.0"
   },
   "scripts": {
-    "test": "npm run eslint && npm run coverage",
-    "coverage": "nyc npm run mocha",
+    "test": "npm run eslint && npm run coverage --",
+    "coverage": "nyc npm run mocha --",
     "eslint": "eslint src/. test/. --config .eslintrc.json",
     "dev": "nodemon src/",
     "start": "node src/",


### PR DESCRIPTION
This commit allows running for example just:

    npm test -- -g 'authentication'

instead of the previously needed:

    npm test -- -- -- -g 'authentication'

since each npm run consumes one --.

Related: https://stackoverflow.com/questions/40495116/how-to-pass-a-command-line-argument-to-a-nested-script

Maybe this should be done on the generator instead instead of in this repo, not sure.