### PR TITLE
fix(dx): fix cli install bug and potential debugger port collision

### DIFF
--- a/.replit
+++ b/.replit
@@ -21,7 +21,7 @@ fi
 
 # Helper script to deal with lack of CWD support in the Debugger
 mkdir -p .config
-if [ ! -f "node_modules" ]; then
+if [ ! -f "./.config/replit.mjs" ]; then
 cat << EOF > ./.config/replit.mjs
 // Resolve FEATHERS_DIR path and cd to it
 console.log(process.env.NODE_PATH)
@@ -31,6 +31,14 @@ if (process.env.FEATHERS_DIR) {
   process.chdir(f)
 }
 EOF
+fi
+
+if [ ! -f "./.config/bashrc" ]; then
+cat << EOF > ./.config/replit.mjs
+#!/bin/bash
+node --version
+EOF
+
 fi
 rm tsconfig.json 2> /dev/null # Cleanup upstream debris
 """ # """

--- a/.replit
+++ b/.replit
@@ -8,6 +8,7 @@ npm run dev
 """ # """
 
 compile = """
+echo 'NODE VERSION:' $(node --version)
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i

--- a/.replit
+++ b/.replit
@@ -10,7 +10,8 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  bash -lc "npm i -g @feathersjs/cli"
+  export npm_config_prefix=/home/runner/feathers-chat-21/.config/npm/node_global
+  npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -10,6 +10,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
+  bash -c "node --version"
   npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then

--- a/.replit
+++ b/.replit
@@ -10,8 +10,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  bash -lc "node --version"
-  npm i -g @feathersjs/cli
+  bash -lc "npm i -g @feathersjs/cli"
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -10,7 +10,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  npm_config_prefix="/home/runner/feathers-chat-21/${REPL_SLUG}/npm/node_global"
+  npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
   echo "${npm_config_prefix}"
   npm i -g @feathersjs/cli
 fi

--- a/.replit
+++ b/.replit
@@ -9,10 +9,13 @@ npm run dev
 
 compile = """
 echo 'NODE VERSION:' $(node --version)
+npm i -g @feathersjs/cli
+if ! [ -x "$(command -v feathers)" ]; then
+  npm i -g @feathersjs/cli
+fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i
-  npm i -g @feathersjs/cli
   npm run compile
   npm run migrate
   cd -

--- a/.replit
+++ b/.replit
@@ -8,7 +8,8 @@ npm run dev
 compile = """
 clear
 echo 'NODE VERSION:' $(node --version)
-if ! [ -x "$(command -v feathers)" ]; then
+if [ ! -x "$(command -v feathers)" ]; then
+  export npm_config_yes=true
   export npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
   npm i -g @feathersjs/cli
 fi
@@ -41,7 +42,7 @@ node --version
 EOF
 fi
 
-rm tsconfig.json 2> /dev/null # Cleanup upstream debris
+rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
 """ # """
 
 # Multiple ports

--- a/.replit
+++ b/.replit
@@ -32,11 +32,7 @@ if (process.env.FEATHERS_DIR) {
 }
 EOF
 fi
-""" # """
-
-# Runs after `kill 1` or env changes
-onBoot = """
-rm tsconfig.json 2> /dev/null
+rm tsconfig.json 2> /dev/null # Cleanup upstream debris
 """ # """
 
 # Multiple ports

--- a/.replit
+++ b/.replit
@@ -1,7 +1,5 @@
 hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat"]
 
-entrypoint = "feathers-chat-ts/src/app.ts"
-
 run = """
 cd feathers-chat-ts
 npm run dev
@@ -10,8 +8,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
-  echo "${npm_config_prefix}"
+  export npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
   npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then

--- a/.replit
+++ b/.replit
@@ -45,6 +45,12 @@ fi
 rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
 """ # """
 
+
+[[hints]]
+regex = "Error: listen EADDRINUSE: address already in use"
+message = "Try closing all web clients before running from the debugger or the shell."
+
+
 # Multiple ports
 # https://docs.replit.com/programming-ide/configuring-repl#ports
 [[ports]]
@@ -126,5 +132,6 @@ support = true
       type = "pwa-node"
 
       [debugger.interactive.launchMessage.arguments.env]
+      PORT = 9000
       FEATHERS_DIR = "${this.HOME}/${this.REPL_SLUG}/feathers-chat-ts"
 

--- a/.replit
+++ b/.replit
@@ -1,6 +1,6 @@
 hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat"]
 
-entrypoint = "README.md"
+entrypoint = "feathers-chat-ts/src/app.ts"
 
 run = """
 cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -6,6 +6,7 @@ npm run dev
 """ # """
 
 compile = """
+clear
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
   export npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
@@ -34,12 +35,12 @@ EOF
 fi
 
 if [ ! -f "./.config/bashrc" ]; then
-cat << EOF > ./.config/replit.mjs
+cat << EOF > ./.config/bashrc
 #!/bin/bash
 node --version
 EOF
-
 fi
+
 rm tsconfig.json 2> /dev/null # Cleanup upstream debris
 """ # """
 

--- a/.replit
+++ b/.replit
@@ -6,13 +6,13 @@ if [ ! -x "$(command -v feathers)" ]; then
 fi
 
 cd feathers-chat-ts
+clear
 npm run dev
 """ # """
 
-compile = """
+compile = """ # Runs before debug too. Lacks custom env vars.
 clear
 echo Running compile...
-echo 'NODE VERSION:' $(node --version)
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i

--- a/.replit
+++ b/.replit
@@ -10,7 +10,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  bash -c "node --version"
+  bash -lc "node --version"
   npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then

--- a/.replit
+++ b/.replit
@@ -10,7 +10,8 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  export npm_config_prefix=/home/runner/feathers-chat-21/.config/npm/node_global
+  npm_config_prefix="/home/runner/feathers-chat-21/${REPL_SLUG}/npm/node_global"
+  echo "${npm_config_prefix}"
   npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then

--- a/.replit
+++ b/.replit
@@ -9,7 +9,6 @@ npm run dev
 
 compile = """
 echo 'NODE VERSION:' $(node --version)
-npm i -g @feathersjs/cli
 if ! [ -x "$(command -v feathers)" ]; then
   npm i -g @feathersjs/cli
 fi

--- a/.replit
+++ b/.replit
@@ -1,18 +1,18 @@
 hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat"]
 
 run = """
+if [ ! -x "$(command -v feathers)" ]; then
+  npm i -g @feathersjs/cli
+fi
+
 cd feathers-chat-ts
 npm run dev
 """ # """
 
 compile = """
 clear
+echo Running compile...
 echo 'NODE VERSION:' $(node --version)
-if [ ! -x "$(command -v feathers)" ]; then
-  export npm_config_yes=true
-  export npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
-  npm i -g @feathersjs/cli
-fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i


### PR DESCRIPTION
The debugger was running on the same port as the run button. This is a real hassle in Replit as the run command is executed whenever the port is closed and anything tries to connect to it, including socket.io reconnects.

Also, moved the cli installer to the run command which has all necessary PATH variables to function correctly.

Live Repro: https://replit.com/new/github/FossPrime/feathers-chat 