### PR TITLE
perf(dx): drastic performance improvements on Replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -2,7 +2,7 @@ hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react
 
 run = """
 if [ ! -x "$(command -v feathers)" ]; then
-  npm i -g @feathersjs/cli
+  # npm i -g @feathersjs/cli
 fi
 
 cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -21,7 +21,7 @@ fi
 
 # Helper script to deal with lack of CWD support in the Debugger
 mkdir -p .config
-if [ ! -f "node_modules" ]; then
+if [ ! -f "./.config/replit.mjs" ]; then
 cat << EOF > ./.config/replit.mjs
 // Resolve FEATHERS_DIR path and cd to it
 console.log(process.env.NODE_PATH)
@@ -31,6 +31,14 @@ if (process.env.FEATHERS_DIR) {
   process.chdir(f)
 }
 EOF
+fi
+
+if [ ! -f "./.config/bashrc" ]; then
+cat << EOF > ./.config/replit.mjs
+#!/bin/bash
+node --version
+EOF
+
 fi
 rm tsconfig.json 2> /dev/null # Cleanup upstream debris
 """ # """

--- a/.replit
+++ b/.replit
@@ -1,10 +1,6 @@
 hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat"]
 
 run = """
-if [ ! -x "$(command -v feathers)" ]; then
-  echo "@FEATHERSJS/CLI GLOBAL DOES NOT EXIST"
-fi
-
 cd feathers-chat-ts
 npm run dev
 """ # """
@@ -16,7 +12,7 @@ clear
 echo [Compile]
 if [ ! -d "$SERVER/node_modules" ]; then
   cd $SERVER
-  npm i
+  npm i --quiet
   # npm run compile # Drastically faster dev cold boot without
   npm run migrate
   cd -
@@ -46,6 +42,7 @@ fi
 rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
 
 duration=$SECONDS
+clear
 echo "[Compile] took $(($duration / 60))m$(($duration % 60))s"
 """ # """
 

--- a/.replit
+++ b/.replit
@@ -70,7 +70,7 @@ channel = "stable-22_11"
 
 [env]
 FEATHERS_DIR = "feathers-chat-ts"
-PATH = "/home/runner/$REPL_SLUG/.config/npm/node_global/bin:/home/runner/$REPL_SLUG/node_modules/.bin:/home/runner/feathers-chat-ts/$FEATHERS_DIR/node_modules/.bin"
+PATH = "/home/runner/$REPL_SLUG/.config/npm/node_global/bin:/home/runner/$REPL_SLUG/node_modules/.bin:/home/runner/$REPL_SLUG/$FEATHERS_DIR/node_modules/.bin"
 EDITOR="replit-git-editor"
 npm_config_yes="true"
 npm_config_prefix = "/home/runner/$REPL_SLUG/.config/npm/node_global"

--- a/.replit
+++ b/.replit
@@ -8,6 +8,7 @@ npm run dev
 """ # """
 
 compile = """
+echo 'NODE VERSION:' $(node --version)
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i

--- a/.replit
+++ b/.replit
@@ -10,7 +10,8 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  bash -lc "npm i -g @feathersjs/cli"
+  export npm_config_prefix=/home/runner/feathers-chat-21/.config/npm/node_global
+  npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -2,7 +2,15 @@ hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react
 
 run = """
 if [ ! -x "$(command -v feathers)" ]; then
-  npm i -g @feathersjs/cli
+  NG_DIR=".config/npm/node_global"
+  GM_DIR="$NG_DIR/lib/node_modules"
+  GB_DIR="$NG_DIR/bin"
+  mkdir -p "$GB_DIR"
+  mkdir -p "$GM_DIR"
+  cp -a "$FEATHERS_DIR/node_modules/@feathersjs/cli" "$GM_DIR"
+  cd "$GB_DIR"
+  ln -s feathers ../lib/node_modules/@feathersjs/cli/bin/feathers
+  cd -
 fi
 
 cd feathers-chat-ts
@@ -11,8 +19,9 @@ npm run dev
 """ # """
 
 compile = """ # Runs before debug too. Lacks custom env vars.
+SECONDS=0
 clear
-echo Running compile...
+echo [Compile]
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i
@@ -43,6 +52,13 @@ EOF
 fi
 
 rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
+
+if [ ! -x "$(command -v feathers)" ]; then
+  echo "@FEATHERSJS/CLI GLOBAL DOES NOT YET EXIST"
+fi
+
+duration=$SECONDS
+echo "[Compile] took $(($duration / 60))m$(($duration % 60))s"
 """ # """
 
 
@@ -71,6 +87,7 @@ npm_config_yes="true"
 npm_config_prefix = "/home/runner/$REPL_SLUG/.config/npm/node_global"
 HOSTNAME="0.0.0.0"
 NODE_OPTIONS="--max_old_space_size=384"
+FEATHERS_DIR = "${HOME}/${REPL_SLUG}/feathers-chat-ts"
 
 # Enables Secrets and Repl Auth, without the erratic Replit packagers
 [packager]

--- a/.replit
+++ b/.replit
@@ -10,6 +10,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
+  bash -c "node --version"
   npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then

--- a/.replit
+++ b/.replit
@@ -13,8 +13,10 @@ echo [Compile]
 if [ ! -d "$FEATHERS_DIR/node_modules" ]; then
   cd $FEATHERS_DIR
   npm i > /dev/null
+  export PERF1=$SECONDS
   # npm run compile # Drastically faster dev cold boot without
   npm run migrate
+  export PERF2=$(($SECONDS - $PERF2))
   cd -
 fi
 
@@ -41,9 +43,8 @@ INDEX_TS="$FEATHERS_DIR/src/index.ts"
 if ! grep -q "console.time" "$INDEX_TS"; then
 sed -i "1i console.time('App startup time')" "$INDEX_TS"
 sed -i "/Feathers app listening on /a console.timeEnd('App startup time')" "$INDEX_TS"
-duration=$SECONDS
 clear
-echo "[Compile] took $(($duration / 60))m$(($duration % 60))s"
+echo "[Compile] took ${SECONDS}s. ($PERF1 + $PERF2)"
 else
 clear
 fi

--- a/.replit
+++ b/.replit
@@ -10,8 +10,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  bash -lc "node --version"
-  npm i -g @feathersjs/cli
+  bash -lc "npm i -g @feathersjs/cli"
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -16,7 +16,7 @@ echo Running compile...
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i
-  npm run compile
+  # npm run compile # Drastically faster dev cold boot without
   npm run migrate
   cd -
 fi

--- a/.replit
+++ b/.replit
@@ -10,7 +10,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  npm_config_prefix="/home/runner/feathers-chat-21/${REPL_SLUG}/npm/node_global"
+  npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
   echo "${npm_config_prefix}"
   npm i -g @feathersjs/cli
 fi

--- a/.replit
+++ b/.replit
@@ -9,10 +9,13 @@ npm run dev
 
 compile = """
 echo 'NODE VERSION:' $(node --version)
+npm i -g @feathersjs/cli
+if ! [ -x "$(command -v feathers)" ]; then
+  npm i -g @feathersjs/cli
+fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i
-  npm i -g @feathersjs/cli
   npm run compile
   npm run migrate
   cd -

--- a/.replit
+++ b/.replit
@@ -7,7 +7,7 @@ if [ ! -x "$(command -v feathers)" ]; then
   GB_DIR="$NG_DIR/bin"
   mkdir -p "$GB_DIR"
   mkdir -p "$GM_DIR"
-  cp -a "$FEATHERS_DIR/node_modules/@feathersjs/cli" "$GM_DIR"
+  cp -a "$FEATHERS_DIR/node_modules/@feathersjs/cli" "$GM_DIR/@feathersjs"
   cd "$GB_DIR"
   ln -s feathers ../lib/node_modules/@feathersjs/cli/bin/feathers
   cd -

--- a/.replit
+++ b/.replit
@@ -8,7 +8,8 @@ npm run dev
 compile = """
 clear
 echo 'NODE VERSION:' $(node --version)
-if ! [ -x "$(command -v feathers)" ]; then
+if [ ! -x "$(command -v feathers)" ]; then
+  export npm_config_yes=true
   export npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
   npm i -g @feathersjs/cli
 fi
@@ -41,7 +42,7 @@ node --version
 EOF
 fi
 
-rm tsconfig.json 2> /dev/null # Cleanup upstream debris
+rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
 """ # """
 
 # Multiple ports

--- a/.replit
+++ b/.replit
@@ -39,7 +39,7 @@ fi
 if [ ! -f "./.config/bashrc" ]; then
 cat << EOF > ./.config/bashrc
 #!/bin/bash
-echo Node version: node --version
+echo Node version: "$(node --version)"
 EOF
 fi
 
@@ -52,7 +52,7 @@ if [ ! -x "$(command -v feathers)" ]; then
   mkdir -p "$GB_DIR"
   mkdir -p "$GM_DIR/@feathersjs"
   cp -a "$FEATHERS_DIR/node_modules/@feathersjs/cli" "$GM_DIR/@feathersjs"
-  ln -s "${HOME}/${REPL_SLUG}/@feathersjs/cli/bin/feathers" "$GB_DIR"
+  ln -s "$HOME/$REPL_SLUG/$GM_DIR/@feathersjs/cli/bin/feathers" "$GB_DIR"
 fi
 
 duration=$SECONDS

--- a/.replit
+++ b/.replit
@@ -32,11 +32,7 @@ if (process.env.FEATHERS_DIR) {
 }
 EOF
 fi
-""" # """
-
-# Runs after `kill 1` or env changes
-onBoot = """
-rm tsconfig.json 2> /dev/null
+rm tsconfig.json 2> /dev/null # Cleanup upstream debris
 """ # """
 
 # Multiple ports

--- a/.replit
+++ b/.replit
@@ -1,7 +1,5 @@
 hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat"]
 
-entrypoint = "feathers-chat-ts/src/app.ts"
-
 run = """
 cd feathers-chat-ts
 npm run dev
@@ -10,8 +8,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
-  echo "${npm_config_prefix}"
+  export npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
   npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then

--- a/.replit
+++ b/.replit
@@ -2,17 +2,10 @@ hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react
 
 run = """
 if [ ! -x "$(command -v feathers)" ]; then
-  NG_DIR=".config/npm/node_global"
-  GM_DIR="$NG_DIR/lib/node_modules"
-  GB_DIR="$NG_DIR/bin"
-  mkdir -p "$GB_DIR"
-  mkdir -p "$GM_DIR/@feathersjs"
-  cp -a "$FEATHERS_DIR/node_modules/@feathersjs/cli" "$GM_DIR/@feathersjs"
-  ln -s "${HOME}/${REPL_SLUG}/@feathersjs/cli/bin/feathers" "$GB_DIR"
+  echo "@FEATHERSJS/CLI GLOBAL DOES NOT EXIST"
 fi
 
 cd feathers-chat-ts
-clear
 npm run dev
 """ # """
 
@@ -45,14 +38,20 @@ fi
 if [ ! -f "./.config/bashrc" ]; then
 cat << EOF > ./.config/bashrc
 #!/bin/bash
-node --version
+echo Node version: node --version
 EOF
 fi
 
 rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
 
 if [ ! -x "$(command -v feathers)" ]; then
-  echo "@FEATHERSJS/CLI GLOBAL DOES NOT YET EXIST"
+  NG_DIR=".config/npm/node_global"
+  GM_DIR="$NG_DIR/lib/node_modules"
+  GB_DIR="$NG_DIR/bin"
+  mkdir -p "$GB_DIR"
+  mkdir -p "$GM_DIR/@feathersjs"
+  cp -a "$FEATHERS_DIR/node_modules/@feathersjs/cli" "$GM_DIR/@feathersjs"
+  ln -s "${HOME}/${REPL_SLUG}/@feathersjs/cli/bin/feathers" "$GB_DIR"
 fi
 
 duration=$SECONDS

--- a/.replit
+++ b/.replit
@@ -35,6 +35,12 @@ cat << EOF > ./.config/bashrc
 #!/bin/bash
 echo Node version: "$(node --version)"
 EOF
+fi
+
+INDEX_TS="$FEATHERS_DIR/src/index.ts"
+if ! grep -q "console.time" "$INDEX_TS"; then
+sed -i "1i console.time('App startup time')" "$INDEX_TS"
+sed -i "/Feathers app listening on /a console.timeEnd('App startup time')" "$INDEX_TS"
 duration=$SECONDS
 clear
 echo "[Compile] took $(($duration / 60))m$(($duration % 60))s"

--- a/.replit
+++ b/.replit
@@ -69,13 +69,13 @@ externalPort = 9000
 channel = "stable-22_11"
 
 [env]
-PATH = "/home/runner/$REPL_SLUG/.config/npm/node_global/bin:/home/runner/$REPL_SLUG/node_modules/.bin:/home/runner/feathers-chat-ts/node_modules/.bin"
+FEATHERS_DIR = "feathers-chat-ts"
+PATH = "/home/runner/$REPL_SLUG/.config/npm/node_global/bin:/home/runner/$REPL_SLUG/node_modules/.bin:/home/runner/feathers-chat-ts/$FEATHERS_DIR/node_modules/.bin"
 EDITOR="replit-git-editor"
 npm_config_yes="true"
 npm_config_prefix = "/home/runner/$REPL_SLUG/.config/npm/node_global"
 HOSTNAME="0.0.0.0"
 NODE_OPTIONS="--max_old_space_size=384"
-FEATHERS_DIR = "${HOME}/${REPL_SLUG}/feathers-chat-ts"
 
 # Enables Secrets and Repl Auth, without the erratic Replit packagers
 [packager]

--- a/.replit
+++ b/.replit
@@ -7,11 +7,11 @@ npm run dev
 
 compile = """ # Runs before debug too. Lacks custom env vars.
 SECONDS=0
-SERVER="feathers-chat-ts"
+FEATHERS_DIR="feathers-chat-ts"
 clear
 echo [Compile]
-if [ ! -d "$SERVER/node_modules" ]; then
-  cd $SERVER
+if [ ! -d "$FEATHERS_DIR/node_modules" ]; then
+  cd $FEATHERS_DIR
   npm i --quiet
   # npm run compile # Drastically faster dev cold boot without
   npm run migrate
@@ -22,12 +22,8 @@ fi
 mkdir -p .config
 if [ ! -f "./.config/replit.mjs" ]; then
 cat << EOF > ./.config/replit.mjs
-// Resolve FEATHERS_DIR path and cd to it
-console.log(process.env.NODE_PATH)
 if (process.env.FEATHERS_DIR) {
-  const p = process.env.FEATHERS_DIR
-  const f = new Function('return \\`' + p + '\\`;').call(process.env)
-  process.chdir(f)
+  process.chdir(process.env.FEATHERS_DIR)
 }
 EOF
 fi
@@ -135,5 +131,4 @@ support = true
 
       [debugger.interactive.launchMessage.arguments.env]
       PORT = 9000
-      FEATHERS_DIR = "${this.HOME}/${this.REPL_SLUG}/feathers-chat-ts"
 

--- a/.replit
+++ b/.replit
@@ -45,6 +45,12 @@ fi
 rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
 """ # """
 
+
+[[hints]]
+regex = "Error: listen EADDRINUSE: address already in use"
+message = "Try closing all web clients before running from the debugger or the shell."
+
+
 # Multiple ports
 # https://docs.replit.com/programming-ide/configuring-repl#ports
 [[ports]]
@@ -126,5 +132,6 @@ support = true
       type = "pwa-node"
 
       [debugger.interactive.launchMessage.arguments.env]
+      PORT = 9000
       FEATHERS_DIR = "${this.HOME}/${this.REPL_SLUG}/feathers-chat-ts"
 

--- a/.replit
+++ b/.replit
@@ -1,6 +1,6 @@
 hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat"]
 
-entrypoint = "README.md"
+entrypoint = "feathers-chat-ts/src/app.ts"
 
 run = """
 cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -11,10 +11,11 @@ npm run dev
 
 compile = """ # Runs before debug too. Lacks custom env vars.
 SECONDS=0
+FEATHERS_DIR="${HOME}/${REPL_SLUG}/feathers-chat-ts"
 clear
 echo [Compile]
-if [ ! -d "feathers-chat-ts/node_modules" ]; then
-  cd feathers-chat-ts
+if [ ! -d "$FEATHERS_DIR/node_modules" ]; then
+  cd $FEATHERS_DIR
   npm i
   # npm run compile # Drastically faster dev cold boot without
   npm run migrate

--- a/.replit
+++ b/.replit
@@ -11,11 +11,11 @@ npm run dev
 
 compile = """ # Runs before debug too. Lacks custom env vars.
 SECONDS=0
-FEATHERS_DIR="${HOME}/${REPL_SLUG}/feathers-chat-ts"
+SERVER="feathers-chat-ts"
 clear
 echo [Compile]
-if [ ! -d "$FEATHERS_DIR/node_modules" ]; then
-  cd $FEATHERS_DIR
+if [ ! -d "$SERVER/node_modules" ]; then
+  cd $SERVER
   npm i
   # npm run compile # Drastically faster dev cold boot without
   npm run migrate
@@ -45,16 +45,6 @@ fi
 
 rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
 
-if [ ! -x "$(command -v feathers)" ]; then
-  NG_DIR=".config/npm/node_global"
-  GM_DIR="$NG_DIR/lib/node_modules"
-  GB_DIR="$NG_DIR/bin"
-  mkdir -p "$GB_DIR"
-  mkdir -p "$GM_DIR/@feathersjs"
-  cp -a "$FEATHERS_DIR/node_modules/@feathersjs/cli" "$GM_DIR/@feathersjs"
-  ln -s "$HOME/$REPL_SLUG/$GM_DIR/@feathersjs/cli/bin/feathers" "$GB_DIR"
-fi
-
 duration=$SECONDS
 echo "[Compile] took $(($duration / 60))m$(($duration % 60))s"
 """ # """
@@ -79,7 +69,7 @@ externalPort = 9000
 channel = "stable-22_11"
 
 [env]
-PATH = "/home/runner/$REPL_SLUG/.config/npm/node_global/bin:/home/runner/$REPL_SLUG/node_modules/.bin"
+PATH = "/home/runner/$REPL_SLUG/.config/npm/node_global/bin:/home/runner/$REPL_SLUG/node_modules/.bin:/home/runner/feathers-chat-ts/node_modules/.bin"
 EDITOR="replit-git-editor"
 npm_config_yes="true"
 npm_config_prefix = "/home/runner/$REPL_SLUG/.config/npm/node_global"

--- a/.replit
+++ b/.replit
@@ -6,11 +6,9 @@ if [ ! -x "$(command -v feathers)" ]; then
   GM_DIR="$NG_DIR/lib/node_modules"
   GB_DIR="$NG_DIR/bin"
   mkdir -p "$GB_DIR"
-  mkdir -p "$GM_DIR"
+  mkdir -p "$GM_DIR/@feathersjs"
   cp -a "$FEATHERS_DIR/node_modules/@feathersjs/cli" "$GM_DIR/@feathersjs"
-  cd "$GB_DIR"
-  ln -s feathers ../lib/node_modules/@feathersjs/cli/bin/feathers
-  cd -
+  ln -s "${HOME}/${REPL_SLUG}/@feathersjs/cli/bin/feathers" "$GB_DIR"
 fi
 
 cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -6,6 +6,7 @@ npm run dev
 """ # """
 
 compile = """
+clear
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
   export npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
@@ -34,12 +35,12 @@ EOF
 fi
 
 if [ ! -f "./.config/bashrc" ]; then
-cat << EOF > ./.config/replit.mjs
+cat << EOF > ./.config/bashrc
 #!/bin/bash
 node --version
 EOF
-
 fi
+
 rm tsconfig.json 2> /dev/null # Cleanup upstream debris
 """ # """
 

--- a/.replit
+++ b/.replit
@@ -9,13 +9,18 @@ compile = """ # Runs before debug too. Lacks custom env vars.
 SECONDS=0
 FEATHERS_DIR="feathers-chat-ts"
 clear
-echo [Compile]
+echo [compile]
+
 if [ ! -d "$FEATHERS_DIR/node_modules" ]; then
   cd $FEATHERS_DIR
-  npm i > /dev/null
+  npm i &> /dev/null
   export PERF1=$SECONDS
-  # npm run compile # Drastically faster dev cold boot without
   # npm run migrate # Most of the time, optional
+  
+  # For TS clients
+  # npm run compile # Drastically faster dev cold boot without
+  # npm run bundle:client # Generates .tgz types for loading into TS clients
+  
   export PERF2=$(($SECONDS - $PERF1))
   cd -
 fi
@@ -44,7 +49,7 @@ if ! grep -q "console.time" "$INDEX_TS"; then
 sed -i "1i console.time('App startup time')" "$INDEX_TS"
 sed -i "/Feathers app listening on /a console.timeEnd('App startup time')" "$INDEX_TS"
 clear
-echo "[Compile] took ${SECONDS}s. ($PERF1 + $PERF2)"
+echo "[compile] took ${SECONDS}s. ($PERF1 + $PERF2)"
 else
 clear
 fi
@@ -73,18 +78,13 @@ channel = "stable-22_11"
 FEATHERS_DIR = "feathers-chat-ts"
 PATH = "/home/runner/$REPL_SLUG/.config/npm/node_global/bin:/home/runner/$REPL_SLUG/node_modules/.bin:/home/runner/$REPL_SLUG/$FEATHERS_DIR/node_modules/.bin"
 EDITOR="replit-git-editor"
-npm_config_yes="true"
 npm_config_prefix = "/home/runner/$REPL_SLUG/.config/npm/node_global"
 HOSTNAME="0.0.0.0"
 NODE_OPTIONS="--max_old_space_size=384"
 
-# Enables Secrets and Repl Auth, without the erratic Replit packagers
+# Enables Secrets and Auth, without the Replit packager
 [packager]
 language = "bash"
-
-# Todo: Currently uses mocha by default, use npm run test instead or Test Runner
-# [unitTest]
-# language = "nodejs"
 
 [languages.typescript]
 pattern = "**/{*.ts,*.js,*.tsx,*.jsx}"

--- a/.replit
+++ b/.replit
@@ -12,7 +12,7 @@ clear
 echo [Compile]
 if [ ! -d "$FEATHERS_DIR/node_modules" ]; then
   cd $FEATHERS_DIR
-  npm i --quiet
+  npm i > /dev/null
   # npm run compile # Drastically faster dev cold boot without
   npm run migrate
   cd -

--- a/.replit
+++ b/.replit
@@ -15,8 +15,8 @@ if [ ! -d "$FEATHERS_DIR/node_modules" ]; then
   npm i > /dev/null
   export PERF1=$SECONDS
   # npm run compile # Drastically faster dev cold boot without
-  npm run migrate
-  export PERF2=$(($SECONDS - $PERF2))
+  # npm run migrate # Most of the time, optional
+  export PERF2=$(($SECONDS - $PERF1))
   cd -
 fi
 

--- a/.replit
+++ b/.replit
@@ -2,7 +2,7 @@ hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react
 
 run = """
 if [ ! -x "$(command -v feathers)" ]; then
-  # npm i -g @feathersjs/cli
+  npm i -g @feathersjs/cli
 fi
 
 cd feathers-chat-ts

--- a/.replit
+++ b/.replit
@@ -6,13 +6,13 @@ if [ ! -x "$(command -v feathers)" ]; then
 fi
 
 cd feathers-chat-ts
+clear
 npm run dev
 """ # """
 
-compile = """
+compile = """ # Runs before debug too. Lacks custom env vars.
 clear
 echo Running compile...
-echo 'NODE VERSION:' $(node --version)
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i

--- a/.replit
+++ b/.replit
@@ -10,7 +10,7 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  bash -c "node --version"
+  bash -lc "node --version"
   npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then

--- a/.replit
+++ b/.replit
@@ -10,7 +10,8 @@ npm run dev
 compile = """
 echo 'NODE VERSION:' $(node --version)
 if ! [ -x "$(command -v feathers)" ]; then
-  export npm_config_prefix=/home/runner/feathers-chat-21/.config/npm/node_global
+  npm_config_prefix="/home/runner/feathers-chat-21/${REPL_SLUG}/npm/node_global"
+  echo "${npm_config_prefix}"
   npm i -g @feathersjs/cli
 fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then

--- a/.replit
+++ b/.replit
@@ -9,7 +9,6 @@ npm run dev
 
 compile = """
 echo 'NODE VERSION:' $(node --version)
-npm i -g @feathersjs/cli
 if ! [ -x "$(command -v feathers)" ]; then
   npm i -g @feathersjs/cli
 fi

--- a/.replit
+++ b/.replit
@@ -28,18 +28,19 @@ if (process.env.FEATHERS_DIR) {
 EOF
 fi
 
+rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
+
 if [ ! -f "./.config/bashrc" ]; then
 cat << EOF > ./.config/bashrc
 #!/bin/bash
 echo Node version: "$(node --version)"
 EOF
-fi
-
-rm tsconfig.json 2> /dev/null || : # Cleanup upstream debris
-
 duration=$SECONDS
 clear
 echo "[Compile] took $(($duration / 60))m$(($duration % 60))s"
+else
+clear
+fi
 """ # """
 
 

--- a/.replit
+++ b/.replit
@@ -1,18 +1,18 @@
 hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat"]
 
 run = """
+if [ ! -x "$(command -v feathers)" ]; then
+  npm i -g @feathersjs/cli
+fi
+
 cd feathers-chat-ts
 npm run dev
 """ # """
 
 compile = """
 clear
+echo Running compile...
 echo 'NODE VERSION:' $(node --version)
-if [ ! -x "$(command -v feathers)" ]; then
-  export npm_config_yes=true
-  export npm_config_prefix="/home/runner/${REPL_SLUG}/npm/node_global"
-  npm i -g @feathersjs/cli
-fi
 if [ ! -d "feathers-chat-ts/node_modules" ]; then
   cd feathers-chat-ts
   npm i

--- a/replit.nix
+++ b/replit.nix
@@ -1,6 +1,5 @@
 { pkgs }: {
   deps = [
-    pkgs.bashInteractive
     pkgs.nodejs-19_x
       pkgs.nodePackages.typescript-language-server
   ];

--- a/replit.nix
+++ b/replit.nix
@@ -2,6 +2,6 @@
   deps = [
     pkgs.bashInteractive
     pkgs.nodejs-19_x
-    # pkgs.nodePackages.typescript-language-server
+      pkgs.nodePackages.typescript-language-server
   ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -2,6 +2,5 @@
   deps = [
     pkgs.nodejs-19_x
       pkgs.nodePackages.typescript-language-server
-      pkgs.nodePackages.pnpm
   ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -2,6 +2,6 @@
   deps = [
     pkgs.bashInteractive
     pkgs.nodejs-19_x
-      pkgs.nodePackages.typescript-language-server
+    # pkgs.nodePackages.typescript-language-server
   ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -2,5 +2,6 @@
   deps = [
     pkgs.nodejs-19_x
       pkgs.nodePackages.typescript-language-server
+      pkgs.nodePackages.pnpm
   ];
 }


### PR DESCRIPTION
Time from clicking run to listen:

4-core pro plan:
- Before: 1m04s
- After: 12s

0.5 core free plan:
- Before: 3m03s
- After: 59.3s

Try it yourself: https://github.com/FossPrime/feathers-chat

I tried PNPM and that shaved 10s from free, but it produced ugly permission errors. There may be a way to fix those.