### PR TITLE
fix: bundle:client had an out dated public asset path

### DIFF
--- a/.replit
+++ b/.replit
@@ -15,7 +15,7 @@ if [ ! -d "$FEATHERS_DIR/node_modules" ]; then
   cd $FEATHERS_DIR
   npm i &> /dev/null
   export PERF1=$SECONDS
-  # npm run migrate # Most of the time, optional
+  npm run migrate # Sets up the tables, login will not work without this!l
   
   # For TS clients
   # npm run compile # Drastically faster dev cold boot without

--- a/feathers-chat-ts/package.json
+++ b/feathers-chat-ts/package.json
@@ -41,7 +41,7 @@
     "prettier": "npx prettier \"**/*.ts\" --write",
     "mocha": "cross-env NODE_ENV=test mocha test/ --require ts-node/register --recursive --extension .ts --exit",
     "test": "cross-env NODE_ENV=test npm run migrate && npm run mocha",
-    "bundle:client": "npm run compile && npm pack --pack-destination ./public",
+    "bundle:client": "npm run compile && npm pack --pack-destination ../public",
     "migrate": "knex migrate:latest",
     "migrate:make": "knex migrate:make"
   },


### PR DESCRIPTION
This seems like a bit of old code. The react server really needs this.

This fixes an issue where running bundle:client results in an error claiming public does not exist. 

This feathers server uses `../public` not `./public`