### PR TITLE
fix: hide node_modules for packages

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,4 +1,7 @@
-hidden=[".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat"]
+hidden=[
+  ".config", ".github", ".gitignore", ".prettierrc", "quick-start", "react-chat", 
+  "feathers-chat-ts/node_modules", "react-chat/node_modules",  "quick-start/node_modules"
+]
 
 run = """
 cd feathers-chat-ts


### PR DESCRIPTION
Hide node_modules

To run this pull request in a clean container visit:
1. Visit https://replit.com/new/github/feathersjs/feathers-chat
2. Run git pull origin pull/258/head

