### PR TITLE
docs: add instructions for building the React app

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,31 @@ A plain JavaScript frontend can be found in the [public](./public/) folder which
 
 ### React
 
-TBD
+The React example lives in the [react-chat](./react-chat/) folder. It depends on the [generated client package tarball](https://feathersjs.com/guides/cli/client) that is built from the API project and installed locally from the filesystem.
+
+Step 1 — Build and bundle the client from the API project:
+```shell
+cd feathers-chat-ts
+npm install
+npm run bundle:client
+```
+This creates `../public/feathers-chat-0.0.0.tgz` (relative to `feathers-chat-ts`).
+
+Step 2 — Install dependencies and run the React app:
+```shell
+cd ../react-chat
+npm install
+npm start
+```
+
+Open http://localhost:3000 in your browser. The React app connects to the API at http://localhost:3030 via WebSockets.
+
+Note:
+- You still need to have the API running in a separate terminal for the app to work (WebSockets and REST at http://localhost:3030):
+  ```shell
+  cd feathers-chat-ts
+  npm run dev    # or: npm start
+  ```
 
 ### VueJS
 

--- a/react-chat/package.json
+++ b/react-chat/package.json
@@ -11,7 +11,7 @@
     "@types/node": "^16.18.11",
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
-    "feathers-chat": "http://localhost:3030/feathers-chat-0.0.0.tgz",
+    "feathers-chat": "file:../public/feathers-chat-0.0.0.tgz",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",


### PR DESCRIPTION
### Summary

Issues: 
1. The docs do not describe how to build the React app.
2. After successfully building a `.tgz` file, it cannot be installed by the React app. The npm cli errors with "integrity checksum failed when using sha512". 

Contribution:
- The npm integrity checksum error was fixed by changing the feathers-chat dependency from an HTTP URL to a local file reference in `react-chat/package.json`. 
- Documentation was updated to reflect the installation process.
